### PR TITLE
feat: add Makefile and CI workflow skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v1
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Lint
+        run: uv run pre-commit run --all-files --show-diff-on-failure --color=always
+      - name: Type check
+        run: uv run mypy .
+      - name: Tests
+        run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.RECIPEPREFIX := >
+
+up: ## start local stack
+>docker compose -f infra/docker-compose.yml up -d
+
+down: ## stop stack
+>docker compose -f infra/docker-compose.yml down -v
+
+logs: ## follow logs
+>docker compose -f infra/docker-compose.yml logs -f --tail=200
+
+init-db: ## create schema & extensions
+>psql $$POSTGRES_URL -f sql/schema.sql
+
+ingest: ## run all collectors once
+>uv run python -m collectors.gdelt && \
+>uv run python -m collectors.sec && \
+>uv run python -m collectors.stocktwits
+
+score: ## recompute signals for last N hours
+>uv run python -m pipelines.scorer --hours 24
+
+backtest: ## run backtest
+>uv run python -m pipelines.backtest --window 1d
+
+.PHONY: up down logs init-db ingest score backtest


### PR DESCRIPTION
## Summary
- add Makefile with up, down, logs, init-db, ingest, score, and backtest aliases
- add GitHub Actions workflow for linting, type checking, and testing on Python 3.11 and 3.12

## Testing
- `uv run pre-commit run --files .github/workflows/ci.yml`
- `uv run mypy .` *(fails: missing type annotations in scripts/issues_script/create_gh_issues.py)*
- `uv run pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b3f4f1c83299a79339a9265a413